### PR TITLE
update express to version 4

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,3 +1,4 @@
+
 {
   "name": "absolutecoin-node-api",
 	"author": "Niel de la Rouviere",
@@ -10,7 +11,7 @@
 	},
 
 	"dependencies":{
-		"express": "3.3.x",
+		"express": "^4.0.0",
     "node-absolutecoin": "1.0.4",
     "md5": "2.2.1"
 	},
@@ -21,3 +22,4 @@
     "api"
   ]
 }
+


### PR DESCRIPTION
Updates express to version 4.

A review of the code indicates that no other parts are affected by the breaking changes in the library update.